### PR TITLE
Enable allowWaveSimulation to fix launchpad

### DIFF
--- a/content/planets/Gheţar.hjson
+++ b/content/planets/Gheţar.hjson
@@ -10,7 +10,8 @@
     defaultCore: "core-2",
     clearSectorOnLose: true,
     allowSectorInvasion: false,
-	allowLaunchToNumbered: false,
+    allowLaunchToNumbered: false,
+    allowWaveSimulation: true,
     radius: 1,
     hiddenItems: [
         "copper",

--- a/content/planets/Zilo.hjson
+++ b/content/planets/Zilo.hjson
@@ -16,7 +16,8 @@
     sectorSize: 1,
     clearSectorOnLose: true,
     allowSectorInvasion: false,
-	allowLaunchToNumbered: false,
+    allowLaunchToNumbered: false,
+    allowWaveSimulation: true,
     radius: 1,
     hiddenItems: [
         "copper",


### PR DESCRIPTION
This will fix launchpad.
Right now it's not possible to send resources to the currently played sector because you can't switch to another sector.
But maybe it was intentionally wasn't enabled.