### PR TITLE
moonstone research to "OnSector"

### DIFF
--- a/content/blocks/distribution/moonstone-conveyor.hjson
+++ b/content/blocks/distribution/moonstone-conveyor.hjson
@@ -14,7 +14,7 @@ research: {
     parent: "yttrium-bridge",
     objectives: [
         {
-            type: "SectorComplete",
+            type: "OnSector",
             preset: "Secret-passage"
         }
     ]


### PR DESCRIPTION
Misalignment: The Secret Passage dialog after mining moonstone suggests upgrading conveyors, but the moonstone conveyors are locked behind completion of the sector.

It is also difficult to move items quickly in such a narrow sector with very difficult enemies. It seems like the intention was to introduce the moonstone conveyor here, as moonstone has no other use without attacking the Cold Seaside.